### PR TITLE
Update No_Implanted_Devices.xml

### DIFF
--- a/No_Implanted_Devices.xml
+++ b/No_Implanted_Devices.xml
@@ -7,7 +7,7 @@
         <templateId root="2.16.840.1.113883.10.20.22.2.7.1"/>
         <code code="47519-4" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="HISTORY OF PROCEDURES"/>
         <title>PROCEDURES</title>
-        <text><paragraph ID="Proc">No Procedure information. UDI: No implanted devices</paragraph></text>				
+        <text><paragraph ID="Proc1">No Procedure information. UDI: No implanted devices</paragraph></text>				
         <entry>
             <procedure classCode="PROC" moodCode="EVN" negationInd="true">
                 <!-- Procedure Activity Procedure V2-->


### PR DESCRIPTION
ID on line 10 updated from Proc to Proc1 so that the reference link is valid.
Related IG Rule (from MDHT):
Consol Procedure Activity Procedure reference/@value SHALL begin with a '#' and SHALL point to its corresponding narrative (using the approach defined in CDA Release 2, section 4.3.5.1) (CONF:15910, R2.0=CONF:1098-19206)